### PR TITLE
Handle spaces and special characters in kernel filenames

### DIFF
--- a/secureboot-nobara.sh
+++ b/secureboot-nobara.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s nullglob
 echo "Based on sbctl on https://github.com/Foxboron/sbctl"
 echo "\nAlso huge thanks to u/Asphalt_Expert on reddit for his tutorial\n"
 
@@ -73,10 +74,10 @@ done
 
 # Sign kernel images
 echo -e "\n=== Checking kernel images ==="
-kernels=$(ls -1 /boot/vmlinuz-* 2>/dev/null || true)
+kernels=(/boot/vmlinuz-*)
 
-if [[ -n "$kernels" ]]; then
-    for kernel in $kernels; do
+if [[ ${#kernels[@]} -gt 0 ]]; then
+    for kernel in "${kernels[@]}"; do
         echo "Signing kernel: $kernel"
         sbctl sign -s "$kernel" || echo "⚠️ Failed to sign $kernel"
     done


### PR DESCRIPTION
This is just a little change to safely handle vmlinuz-* files with special characters like spaces. While such names shouldn't exist in practice, this patch accommodates users with custom kernels and gives peace of mind.

Without this change, a space in the filename will cause it to be wrongly treated as two filenames instead of one, and special characters could execute arbitrary commands due to the unquoted expansion. Because the script runs as root, this is very dangerous.

The new strategy is to use globbing to initialize an array of filenames, then iterating over each array element.